### PR TITLE
Update icarFeedTransactionReasonType.json

### DIFF
--- a/enums/icarFeedTransactionReasonType.json
+++ b/enums/icarFeedTransactionReasonType.json
@@ -8,6 +8,8 @@
         "TransferOut",
         "Discarded",
         "Wasted",
-        "Adjusted"
+        "Adjusted",
+        "Grown",
+        "Used"
     ]
 }


### PR DESCRIPTION
"Grown" and "Used" added to enum list of feed transaction reasons.  Required by Trev data mapping