### PR TITLE
Update icarFeedReferenceType.json

### DIFF
--- a/types/icarFeedReferenceType.json
+++ b/types/icarFeedReferenceType.json
@@ -4,7 +4,7 @@
     "$id": "types/icarFeedReferenceType",
     "allOf": [
         {
-            "$ref": "../types/icarResourceReferenceType.json"
+            "$ref": "../types/icarProductReferenceType.json"
         }
     ],
     "properties": {


### PR DESCRIPTION
icarFeedReferenceType updated to match change made to Develop branch of ICAR.

In particular this extends icarProductReferenceType rather than icarResourceReferenceType.